### PR TITLE
Add Delete Chat Feature with Confirmation in Sidebar (Fixes #4)

### DIFF
--- a/components/sidebar.py
+++ b/components/sidebar.py
@@ -101,19 +101,47 @@ def render_sidebar():
             st.markdown("---")
 
         if st.session_state.conversations:
-            for i, convo in enumerate(st.session_state.conversations):
-                is_active = i == st.session_state.active_conversation
-                button_style_icon = "🟢" if is_active else "📝"
+            if "delete_candidate" not in st.session_state:
+                for i, convo in enumerate(st.session_state.conversations):
+                    is_active = i == st.session_state.active_conversation
+                    button_style_icon = "🟢" if is_active else "📝"
 
-                if st.button(
-                    f"{button_style_icon} {convo['title'][:22]}...",
-                    key=f"convo_{i}",
-                    help=f"Started: {convo['date']}",
-                    use_container_width=True,
-                    type="primary" if is_active else "secondary"
-                ):
-                    st.session_state.active_conversation = i
+                    col1, col2 = st.columns([5, 1])
+                    with col1:
+                        if st.button(
+                            f"{button_style_icon} {convo['title'][:22]}...",
+                            key=f"convo_{i}",
+                            help=f"Started: {convo['date']}",
+                            use_container_width=True
+                        ):
+                            st.session_state.active_conversation = i
+                            st.rerun()
+                    with col2:
+                        if st.button("🗑️", key=f"delete_{i}"):
+                            st.session_state.delete_candidate = i
+                            st.rerun()
+
+            else:
+                st.warning("⚠️ Are you sure you want to delete this conversation?")
+                col_confirm, col_cancel = st.columns(2)
+
+                if col_confirm.button("Yes, delete", key="confirm_delete"):
+                    del st.session_state.conversations[st.session_state.delete_candidate]
+                    del st.session_state.delete_candidate
+                    st.session_state.active_conversation = -1
                     st.rerun()
+
+                if "cancel_clicked" not in st.session_state:
+                    st.session_state.cancel_clicked = False
+
+                if col_cancel.button("Cancel", key="cancel_delete"):
+                    if not st.session_state.cancel_clicked:
+                        st.session_state.cancel_clicked = True
+                        del st.session_state.delete_candidate
+                        st.rerun()
+                else:
+                    st.session_state.cancel_clicked = False
+
         else:
             st.info("No conversations yet. Start a new chat!")
 


### PR DESCRIPTION
This PR implements the delete chat functionality requested in Issue #4.

• Added a delete icon beside each saved conversation in the sidebar.
• On clicking delete, a confirmation prompt is shown to avoid accidental deletion.
• If confirmed, the chat is removed from st.session_state.conversations and the active conversation is reset if needed.
• This feature improves user control over their conversations, especially considering the mental health context of the app —     allowing users to remove chats they may not wish to revisit.

Fixes #4

GSSoC'25 Contributor

<img width="548" height="512" alt="image" src="https://github.com/user-attachments/assets/abe5aa9c-f63c-4f6c-be0a-ce5fc74ae37f" />
<img width="488" height="418" alt="image" src="https://github.com/user-attachments/assets/679c714d-b7af-4881-8068-19e333cfa0e8" />
