### PR TITLE
chore: cleanup requirements.txt (remove duplicate pandas)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,5 +16,4 @@ pygame
 streamlit-modal
 streamlit_js_eval
 scikit-learn
-pandas
 numpy


### PR DESCRIPTION
### What I did
- Removed duplicate `pandas` entry from requirements.txt (was listed twice: line 13 and 19).

### Why
- Prevents confusion during setup
- Keeps dependencies clean and maintainable

### Notes
- Did not pin versions, following maintainer’s guidance to keep them flexible
