### PR TITLE
Fix: Change login validation message from warning to error.

### DIFF
--- a/components/login_page.py
+++ b/components/login_page.py
@@ -197,7 +197,7 @@ def show_login_page():
             st.markdown('<div class="auth-button">', unsafe_allow_html=True)
             if st.button("Sign Up", key="signup_submit"):
                 if not name or not email or not password:
-                    st.warning("Please fill out all fields.")
+                    st.error("**Please fill out all fields.**")
                 else:
                     success, message = register_user(name, email, password)
                     if success:
@@ -219,7 +219,7 @@ def show_login_page():
             st.markdown('<div class="auth-button">', unsafe_allow_html=True)
             if st.button("Send Reset Link", key="forget_submit"):
                 if not email :
-                    st.warning("Please fill out email id")
+                    st.error("**Please fill out email id**")
                 else:
                     success, updated_at = check_user(email)
                     if success:
@@ -230,9 +230,9 @@ def show_login_page():
                             st.session_state.notify_page=True
                             st.rerun()
                         else:
-                            st.error("Error while Sending Email!")
+                            st.error("**Error while Sending Email!**")
                     else:
-                        st.error("User does not exist ! Please Sign Up First")
+                        st.error("**User does not exist ! Please Sign Up First**")
             st.markdown('</div>', unsafe_allow_html=True)
 
             st.markdown('<div class="switch-link">', unsafe_allow_html=True)
@@ -253,9 +253,7 @@ def show_login_page():
             st.markdown('<div class="auth-button">', unsafe_allow_html=True)
             if st.button("Login", key="login_submit"):
                 if not email or not password:
-                    # FIX START: Changed st.warning to st.error for better user feedback
-                    st.error("Please enter your email and password.")
-                    # FIX END
+                    st.error("**Please enter your email and password.**")
                 else:
                     success, user = authenticate_user(email, password)
                     if success:
@@ -270,7 +268,7 @@ def show_login_page():
                         st.rerun()
                                         
                     else:
-                        st.error("Invalid email or password.")
+                        st.error("**Invalid email or password.**")
             st.markdown('</div>', unsafe_allow_html=True)
 
             st.markdown('<div class="auth-button">', unsafe_allow_html=True)

--- a/components/login_page.py
+++ b/components/login_page.py
@@ -253,7 +253,9 @@ def show_login_page():
             st.markdown('<div class="auth-button">', unsafe_allow_html=True)
             if st.button("Login", key="login_submit"):
                 if not email or not password:
-                    st.warning("Please enter your email and password.")
+                    # FIX START: Changed st.warning to st.error for better user feedback
+                    st.error("Please enter your email and password.")
+                    # FIX END
                 else:
                     success, user = authenticate_user(email, password)
                     if success:


### PR DESCRIPTION
This pull request addresses an issue on the login and sign-up pages where validation messages were displayed as a yellow warning.

The fix involves changing the st.warning call to st.error for the "Please fill out all fields" message in components/login_page.py. This ensures that validation errors are displayed in a prominent red color, making them more noticeable and intuitive for the user. A screenshot of the new error message is included for reference.

Cloud Deployment Link : https://talkheal-l8rm8us7qxsfeice693bhx.streamlit.app

<img width="1280" height="832" alt="Screenshot 2025-09-14 at 4 59 18 PM" src="https://github.com/user-attachments/assets/10b598fb-f821-401c-b854-1b187eaa8ca3" />
