### PR TITLE
[BUG] Authentication-related messages are barely visible. #160

### DIFF
--- a/components/login_page.py
+++ b/components/login_page.py
@@ -4,7 +4,18 @@ from auth.auth_utils import register_user, authenticate_user , check_user
 from auth.mail_utils import send_reset_email
 from auth.jwt_utils import create_reset_token
 
+def inject_text_visibility_css():
+    st.markdown("""
+    <style>
+    .block-container, .block-container * {
+        color: #bf4f70 !important;  /* dark pink */
+        font-weight: 600;
+        font-size: 16px;}
+    </style>
+    """, unsafe_allow_html=True)
+
 def show_login_page():
+    inject_text_visibility_css()
     """Renders the login/signup page with the modern dark theme."""
     st.markdown(
         """


### PR DESCRIPTION
closes #160
Streamlit repo link:  https://talkheal-nayna.streamlit.app/

made the `st.error` and `st.warning` texts visible.  added new styles in` login_page.py`

SCREENSHOTS:
<img width="1920" height="1080" alt="Screenshot (52)" src="https://github.com/user-attachments/assets/535ee61e-79a5-4472-953b-ca775bf0ac47" />
<img width="1920" height="1080" alt="Screenshot (53)" src="https://github.com/user-attachments/assets/b1fe79ee-eda6-4267-9e90-abedcf5e7198" />
<img width="1920" height="1080" alt="Screenshot (54)" src="https://github.com/user-attachments/assets/dd434a0a-65f2-4277-887d-26d7fc70a927" />
