### PR TITLE
feat(help-center): redesign help center page with expandable sections

### DIFF
--- a/pages/FAQs.py
+++ b/pages/FAQs.py
@@ -1,17 +1,30 @@
 import streamlit as st
 
+# Page title
 st.markdown("""
     <div style='background-color: #ffe4ef; border-radius: 15px; padding: 2rem; margin-bottom: 2rem;'>
-        <h2 style='color: #d6336c; text-align: center;'>App Overview</h2>
+        <h2 style='color: #d6336c; text-align: center;'>Frequently Asked Questions (FAQs)</h2>
     </div>
 """, unsafe_allow_html=True)
 
+# FAQ container
 st.markdown("""
     <div style='background-color: #fff; border-radius: 10px; box-shadow: 0 2px 8px #d6336c22; padding: 2rem; margin-bottom: 2rem;'>
-        <h3 style='color: #d6336c;'>Welcome to TalkHeal!</h3>
-        <div style='color: #222;'>
-            TalkHeal is your trusted companion for mental wellness, designed to empower you on your journey to emotional health. Our platform combines science-backed tools, expert resources, and a supportive community to help you thrive every day.<br><br>
-            <b>Key Features:</b>
+""", unsafe_allow_html=True)
+
+# Question 1
+with st.expander("What is TalkHeal?"):
+    st.markdown("""
+        <div style='padding: 1rem;'>
+            TalkHeal is your trusted companion for mental wellness, designed to empower you on your journey to emotional health. Our platform combines science-backed tools, expert resources, and a supportive community to help you thrive every day.
+        </div>
+    """, unsafe_allow_html=True)
+
+# Question 2
+with st.expander("What are the key features of TalkHeal?"):
+    st.markdown("""
+        <div style='padding: 1rem;'>
+            <b>Key Features include:</b>
             <ul>
                 <li><b>Mood Tracking:</b> Visualize your emotional patterns and gain insights to improve your well-being.</li>
                 <li><b>Coping Tools:</b> Access quick coping cards, breathing exercises, and journaling to manage stress and anxiety.</li>
@@ -19,16 +32,35 @@ st.markdown("""
                 <li><b>Community Support:</b> Join a safe, inclusive space to share experiences and find encouragement.</li>
                 <li><b>Personalized Dashboard:</b> Track your progress and celebrate your achievements.</li>
             </ul>
-            <br>
-            <b>Why TalkHeal?</b><br>
-            <ul>
-                <li>Beautiful, user-friendly design with soothing colors and intuitive navigation.</li>
-                <li>Privacy-first approach: your data is always secure and confidential.</li>
-                <li>Accessible on all devices—desktop, tablet, and mobile.</li>
-                <li>Free to get started, with premium resources available for deeper support.</li>
-            </ul>
-            <br>
-            <b>Start your journey with TalkHeal and discover a happier, healthier you!</b>
         </div>
-    </div>
-""", unsafe_allow_html=True)
+    """, unsafe_allow_html=True)
+
+# Question 3
+with st.expander("Why should I use TalkHeal?"):
+    st.markdown("""
+        <div style='padding: 1rem;'>
+            TalkHeal is designed with you in mind:
+            <ul>
+                <li>It has a beautiful, user-friendly design with soothing colors and intuitive navigation.</li>
+                <li>It is accessible on all devices—desktop, tablet, and mobile.</li>
+            </ul>
+        </div>
+    """, unsafe_allow_html=True)
+
+# Question 4
+with st.expander("Is TalkHeal free to use?"):
+    st.markdown("""
+        <div style='padding: 1rem;'>
+            Yes, TalkHeal is free to get started. We also offer premium resources for deeper support.
+        </div>
+    """, unsafe_allow_html=True)
+
+# Question 5
+with st.expander("Is my data secure and private?"):
+    st.markdown("""
+        <div style='padding: 1rem;'>
+            Absolutely. We have a privacy-first approach. Your data is always secure and confidential.
+        </div>
+    """, unsafe_allow_html=True)
+
+st.markdown("</div>", unsafe_allow_html=True)

--- a/pages/HelpCenter.py
+++ b/pages/HelpCenter.py
@@ -1,27 +1,90 @@
 import streamlit as st
 
 def show():
+    # Page title
     st.markdown("""
-        <div style='background: linear-gradient(135deg, #ffe4f0 0%, #fff 100%); border-radius: 18px; box-shadow: 0 2px 18px 0 rgba(209,74,122,0.12); padding: 2.5rem 2.5rem 2rem 2.5rem; margin: 2rem auto; max-width: 900px;'>
-            <h2 style='color: #d14a7a; font-family: Baloo 2, cursive;'>Help Center</h2>
-            <div style='color: #222; font-size: 1.1rem;'>
-                Welcome to the TalkHeal Help Center!<br><br>
-                <b>How can we assist you?</b><br>
-                <ul>
-                    <li><b>Getting Started:</b> Learn how to use TalkHeal and explore its features.</li>
-                    <li><b>Account & Privacy:</b> Manage your profile, privacy settings, and data.</li>
-                    <li><b>AI Companion:</b> Tips for interacting with your AI and customizing its tone.</li>
-                    <li><b>Wellness Tools:</b> Discover yoga, journaling, breathing exercises, and more.</li>
-                    <li><b>Support & Feedback:</b> Reach out for help or share your suggestions.</li>
-                </ul>
-                <br>
-                <b>Why TalkHeal?</b><br>
-                TalkHeal is your trusted mental health companion, offering a safe, supportive, and beautifully designed space for healing and growth. Our features are crafted with care, and our community is here to uplift you.<br><br>
-                <b>Need more help?</b><br>
-                Email us at <a href='mailto:support@talkheal.com'>support@talkheal.com</a> or visit the <a href='/FAQs' target='_self'>FAQs</a> page.<br><br>
-                <i>We're here for you, every step of the way!</i>
-            </div>
+        <div style='background: linear-gradient(135deg, #ffe4f0 0%, #fff 100%); border-radius: 18px; box-shadow: 0 2px 18px 0 rgba(209,74,122,0.12); padding: 2.5rem; margin: 2rem auto; max-width: 900px; text-align: center;'>
+            <h1 style='color: #d14a7a; font-family: "Baloo 2", cursive;'>Help Center</h1>
+            <p style='font-size: 1.1rem;'>Your guide to getting the most out of TalkHeal. We're here for you!</p>
         </div>
     """, unsafe_allow_html=True)
+
+    st.write("") # Add some space
+
+    # --- Getting Started ---
+    with st.expander("🚀 Getting Started", expanded=True):
+        st.markdown("""
+            #### Welcome to TalkHeal!
+            Here’s a quick guide to help you get started on your wellness journey:
+        """)
+        col1, col2 = st.columns(2)
+        with col1:
+            st.markdown("""
+                **1. Explore Your Dashboard**
+                <br>Your main screen shows you key features like Yoga, Journaling, and more. Click any card to begin an activity.
+            """, unsafe_allow_html=True)
+        with col2:
+            st.markdown("""
+                **2. Navigate with the Sidebar**
+                <br>Use the sidebar on the left to switch between conversations, start new chats, or review your pinned messages.
+            """, unsafe_allow_html=True)
+        st.markdown("""
+            **3. Chat with Your AI Companion**
+            <br>Simply type your thoughts into the chat box at the bottom of the main page to start a conversation. The AI is here to listen without judgment.
+        """, unsafe_allow_html=True)
+
+
+    # --- Account & Privacy ---
+    with st.expander("👤 Account & Privacy"):
+        st.success("Your privacy is our top priority.")
+        st.markdown("""
+            - **Logging Out:** To log out, simply click the "Logout" button at the top right of the main page.
+            - **Data Privacy:** We take your privacy very seriously. Your conversations are confidential and are not shared. For more details, please read our **[Privacy Policy](/PrivacyPolicy)**.
+        """)
+
+    # --- AI Companion ---
+    with st.expander("🧠 AI Companion"):
+        st.info("You can change your AI's personality to best suit your needs.")
+        st.markdown("""
+            - **Changing Tones:** On the main page, you'll find an expander labeled "Customize Your AI Companion." You can select from several personalities, such as "Compassionate Listener," "Motivating Coach," and more.
+            - **Effective Conversations:** Be open and share what's on your mind. The more context you provide, the better the AI can support you. You can use it for advice, to vent, or even for creative brainstorming.
+        """)
+
+    # --- Wellness Tools ---
+    with st.expander("🛠️ Wellness Tools"):
+        st.markdown("TalkHeal offers a variety of tools to support your mental well-being. Click to explore:")
+        col1, col2, col3 = st.columns(3)
+        with col1:
+            st.page_link("pages/Yoga.py", label="🧘‍♀️ Yoga & Meditation")
+            st.page_link("pages/Breathing_Exercise.py", label="🌬️ Breathing Exercises")
+        with col2:
+            st.page_link("pages/Journaling.py", label="📝 Personal Journaling")
+            st.page_link("pages/selfHelpTools.py", label="🛠️ Self-Help Tools")
+        with col3:
+            st.page_link("pages/WellnessResourceHub.py", label="🌿 Wellness Hub")
+            st.page_link("pages/Habit_Builder.py", label="🎯 Habit Builder")
+
+
+    # --- "Still Need Help?" Section ---
+    st.write("---")
+    st.markdown("""
+        <div style='background-color: #fff0f6; border-radius: 15px; padding: 2rem; margin-top: 2rem; text-align: center;'>
+            <h3 style='color: #d14a7a;'>Still Need Help?</h3>
+            <p>If you can't find the answer you're looking for, we're here to assist.</p>
+        </div>
+    """, unsafe_allow_html=True)
+    
+    col1, col2 = st.columns(2)
+    with col1:
+        st.info("**Contact Support**")
+        st.write("For any technical issues or questions, please email us directly.")
+        st.markdown("[📧 Email support@talkheal.com](mailto:support@talkheal.com)")
+    with col2:
+        st.info("**Provide Feedback**")
+        st.write("Have a suggestion or found a bug? We'd love to hear from you!")
+        st.markdown("[🐞 Report an issue on GitHub](https://github.com/eccentriccoder01/TalkHeal/issues)")
+
+    st.markdown("</div>", unsafe_allow_html=True)
+
 
 show()


### PR DESCRIPTION
This PR redesign help center page 

- Replace static content with expandable sections for better UX
- Add detailed guides for getting started, account privacy, AI companion, and wellness tools
- Include direct links to other wellness tools and contact options

It fixes #237 