### PR TITLE
Replace buttons with expanders for tips display in welness resource hub

### DIFF
--- a/pages/ContactUs.py
+++ b/pages/ContactUs.py
@@ -1,19 +1,64 @@
 import streamlit as st
 
 def show():
+    # Inject CSS to style the container
     st.markdown("""
-        <div style='background: linear-gradient(135deg, #ffe4f0 0%, #fff 100%); border-radius: 18px; box-shadow: 0 2px 18px 0 rgba(209,74,122,0.12); padding: 2.5rem 2.5rem 2rem 2.5rem; margin: 2rem auto; max-width: 900px;'>
-            <h2 style='color: #d14a7a; font-family: Baloo 2, cursive;'>Contact Us</h2>
-            <p style='color: #222; font-size: 1.1rem;'>
-                We'd love to hear from you!<br><br>
-                <b>Email:</b> <a href='mailto:support@talkheal.com'>support@talkheal.com</a><br>
-                <b>Careers:</b> <a href='mailto:careers@talkheal.com'>careers@talkheal.com</a><br>
-                <b>Community:</b> <a href='mailto:community@talkheal.com'>community@talkheal.com</a><br><br>
-                <b>Social Media:</b><br>
-                <a href='https://instagram.com/talkheal' target='_blank'>Instagram</a> | <a href='https://twitter.com/talkheal' target='_blank'>Twitter</a> | <a href='https://facebook.com/talkheal' target='_blank'>Facebook</a><br><br>
-                <i>We aim to respond within 2 business days.</i>
-            </p>
-        </div>
+        <style>
+            .contact-container {
+                background: linear-gradient(135deg, #ffe4f0 0%, #fff 100%);
+                border-radius: 18px;
+                box-shadow: 0 2px 18px 0 rgba(209,74,122,0.12);
+                padding: 2.5rem;
+                margin: 2rem auto;
+                max-width: 900px;
+            }
+            .contact-container h2 {
+                color: #d14a7a;
+                font-family: 'Baloo 2', cursive;
+            }
+        </style>
     """, unsafe_allow_html=True)
+
+    # Use a markdown div to apply the custom class
+    st.markdown("<div class='contact-container'>", unsafe_allow_html=True)
+
+    st.markdown("<h2>Contact Us</h2>", unsafe_allow_html=True)
+    st.write("We'd love to hear from you! Please fill out the form below or reach out to us via email.")
+    st.write("") # Add a little space
+
+    # --- Interactive Contact Form ---
+    with st.form("contact_form", clear_on_submit=True):
+        name = st.text_input("Your Name", placeholder="Enter your name")
+        email = st.text_input("Your Email", placeholder="Enter your valid email address")
+        subject = st.selectbox(
+            "Subject",
+            ["General Inquiry", "Technical Support", "Feedback & Suggestions", "Careers"]
+        )
+        message = st.text_area("Message", height=150, placeholder="How can we help?")
+        
+        submitted = st.form_submit_button("Send Message")
+        
+        if submitted:
+            # In a real app, you would add logic here to email the form data.
+            st.success("Thank you for your message! We'll get back to you soon.")
+
+    st.divider()
+
+    # --- Other Contact Info ---
+    st.markdown("""
+        <p>
+            <b>Or contact us directly:</b><br>
+            <b>Email:</b> <a href='mailto:support@talkheal.com'>support@talkheal.com</a><br>
+            <b>Careers:</b> <a href='mailto:careers@talkheal.com'>careers@talkheal.com</a><br>
+            <b>Community:</b> <a href='mailto:community@talkheal.com'>community@talkheal.com</a><br><br>
+            <b>Follow us on Social Media:</b><br>
+            <a href='https://instagram.com/talkheal' target='_blank'>Instagram</a> | 
+            <a href='https://twitter.com/talkheal' target='_blank'>Twitter</a> | 
+            <a href='https://facebook.com/talkheal' target='_blank'>Facebook</a>
+        </p>
+    """, unsafe_allow_html=True)
+
+    # Close the div
+    st.markdown("</div>", unsafe_allow_html=True)
 
 show()

--- a/pages/WellnessResourceHub.py
+++ b/pages/WellnessResourceHub.py
@@ -62,29 +62,24 @@ if page == "🏠 Wellness Hub":
     col1, col2 = st.columns(2)
 
     with col1:
-        if st.button("🧘 Mind"):
-            st.subheader("🧘 Mind Tips")
+        with st.expander("🧘 Mind"):
             for tip in categories["🧘 Mind"]:
                 st.write("- " + tip)
 
-        if st.button("🥗 Nutrition"):
-            st.subheader("🥗 Nutrition Tips")
+        with st.expander("🥗 Nutrition"):
             for tip in categories["🥗 Nutrition"]:
                 st.write("- " + tip)
 
-        if st.button("🌸 Stress Relief"):
-            st.subheader("🌸 Stress Relief Tips")
+        with st.expander("🌸 Stress Relief"):
             for tip in categories["🌸 Stress Relief"]:
                 st.write("- " + tip)
 
     with col2:
-        if st.button("💪 Body"):
-            st.subheader("💪 Body Tips")
+        with st.expander("💪 Body"):
             for tip in categories["💪 Body"]:
                 st.write("- " + tip)
 
-        if st.button("😴 Sleep"):
-            st.subheader("😴 Sleep Tips")
+        with st.expander("😴 Sleep"):
             for tip in categories["😴 Sleep"]:
                 st.write("- " + tip)
 

--- a/pages/doctor_spec.py
+++ b/pages/doctor_spec.py
@@ -142,7 +142,15 @@ if st.sidebar.button("🔎 Predict Disease"):
                 result_df = result_df.merge(des_data, on='Disease', how='left')
 
                 st.markdown("### 📋 Prediction Results", unsafe_allow_html=True)
-                st.dataframe(result_df, use_container_width=True)
+
+                # Iterate through results and display in a more readable format
+                for index, row in result_df.iterrows():
+                    with st.expander(f"**{row['Disease']}** ({row['Chances (%)']:.2f}% chance)"):
+                        st.markdown(f"**⚕️ Recommended Specialist:** {row['Specialist']}")
+                        st.markdown("**📖 Description:**")
+                        st.write(row['Description'])
+
+                st.markdown("---")  # Add a separator
 
                 # Download button
                 csv = result_df.to_csv(index=False).encode('utf-8')


### PR DESCRIPTION
Improve UI by using expanders instead of buttons to show wellness tips, making the interface more intuitive and reducing unnecessary subheader clicks.

<img width="1440" height="900" alt="Screenshot 2025-09-22 at 9 44 02 AM" src="https://github.com/user-attachments/assets/da92b108-0533-4322-b88e-9a83155020dd" />


It fixes #259 