### PR TITLE
Feat: Implement task editing in Daily Planner (#340)

### DIFF
--- a/pages/WellnessResourceHub.py
+++ b/pages/WellnessResourceHub.py
@@ -208,6 +208,13 @@ elif page == "📅 Daily Planner":
 
     st.subheader("✅ Your Tasks")
 
+    # --- Display Progress Bar ---
+    if st.session_state.tasks:
+        completed_count = sum(1 for t in st.session_state.tasks if t["completed"])
+        total_count = len(st.session_state.tasks)
+        progress_ratio = completed_count / total_count if total_count > 0 else 0
+        st.progress(progress_ratio, text=f"{completed_count}/{total_count} Tasks Completed")
+
     # --- Task Deletion and Completion Logic ---
     indices_to_delete = []
     for i, task in enumerate(st.session_state.tasks):


### PR DESCRIPTION
This PR introduces **task editing functionality** to the **Daily Planner** section of the Wellness Resource Hub, addressing issue **#340**.

### Changes Introduced

* Added an **✏️ Edit** button next to each task.
* On clicking **Edit**, the task switches to an input field pre-filled with the existing task description.
* Added **💾 Save** and **❌ Cancel** options to update or discard changes.
* Improved task management flow by enabling users to refine/edit tasks without deleting and re-adding them.

### Technical Details

* Integrated `uuid` for generating unique keys to reliably identify tasks during editing.
* Leveraged `st.session_state` to manage editing state and track the currently edited task.
* Implemented conditional rendering to switch between:

  * **Normal View** → Checkbox, task text, edit/delete buttons.
  * **Editing View** → Text input, save/cancel buttons.

### Screenshot

<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/4cd3971f-156b-46f4-82b7-1fc9032eb9c3" />

<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/4d35bc44-3bf4-4a42-b7c9-42a5ce33cd22" />

<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/b1a74ff9-5b8e-4116-ae44-5d9f9b6985b0" />



### Linked Issue

Closes #340


