### PR TITLE
Feat: Implement improved habit editing in Habit Builder (#342)

### DIFF
--- a/pages/WellnessResourceHub.py
+++ b/pages/WellnessResourceHub.py
@@ -208,6 +208,13 @@ elif page == "📅 Daily Planner":
 
     st.subheader("✅ Your Tasks")
 
+    # --- Display Progress Bar ---
+    if st.session_state.tasks:
+        completed_count = sum(1 for t in st.session_state.tasks if t["completed"])
+        total_count = len(st.session_state.tasks)
+        progress_ratio = completed_count / total_count if total_count > 0 else 0
+        st.progress(progress_ratio, text=f"{completed_count}/{total_count} Tasks Completed")
+
     # --- Task Deletion and Completion Logic ---
     indices_to_delete = []
     for i, task in enumerate(st.session_state.tasks):

--- a/pages/WellnessResourceHub.py
+++ b/pages/WellnessResourceHub.py
@@ -225,6 +225,11 @@ elif page == "📅 Daily Planner":
         progress_ratio = completed_count / total_count if total_count > 0 else 0
         st.progress(progress_ratio, text=f"{completed_count}/{total_count} Tasks Completed")
 
+        # --- Celebrate Completion ---
+        if completed_count > 0 and completed_count == total_count:
+            st.balloons()
+            st.success("🎉 All tasks completed! Great job!")
+
     # --- Task Display, Edit, and Deletion Logic ---
     indices_to_delete = []
     for i, task in enumerate(st.session_state.tasks):


### PR DESCRIPTION
This PR enhances the **habit editing experience** in the **My Habits** section of the Habit Builder, addressing issue **#342**.

### Changes Introduced

* Added inline **habit editing form** within the habit's expander.
* Pre-fills form with existing habit details:

  * Habit name
  * Category
  * Difficulty
  * Notes
  * Reminder time
* Added **💾 Save Changes** and **❌ Cancel** options for seamless updates.
* Improves usability by letting users update habits without deleting and recreating them.

### Technical Details

* Leveraged `st.session_state` to track and manage editing state per habit (ensuring only one habit is editable at a time).
* Used **conditional rendering** to switch between:

  * Normal view → Habit details & action buttons.
  * Editing view → Input form with save/cancel options.
* Handled **datetime.time** conversion for `st.time_input` and back to string for reliable storage.

### Screenshot

<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/a8f8463c-6ad7-4951-b90d-4c64bbf8601a" />

<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/54f52102-55d8-4ead-b922-ef0834b25f12" />


### Linked Issue

Closes #342